### PR TITLE
Experimental plugin support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baseplate-core",
   "main": "server/index.js",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "license": "MIT",
   "description": "A tool for building prototypes and pattern libraries.",
   "author": "Made Media Ltd. <developers@mademedia.co.uk> (made.media)",

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ var last = require('lodash/last');
 var flatten = require('lodash/flatten');
 var routes = require('./routes');
 var helpers = require('./helpers');
+var plugins = require('./lib/plugins');
 var templateData = require('./lib/templateData');
 
 var AUTH_USER = process.env.AUTH_USER;
@@ -37,7 +38,7 @@ app.use(require('morgan')('dev'));
 app.use(require('compression')());
 app.use(require('errorhandler')());
 
-module.exports = function (styleguideOptions, options) {
+module.exports = function (styleguideOptions, options, helperPlugins) {
     const config = defaults(options, {
         ext: 'html',
         port: process.env.PORT || 4444,
@@ -84,12 +85,17 @@ module.exports = function (styleguideOptions, options) {
             };
         });
 
+    plugins.register(
+        helpers,
+        helperPlugins
+    );
+
     const hbs = expressHbs.create({
         defaultLayout: config.layoutTmpl,
         layoutsDir: viewsDir,
         extname: `.${config.ext}`,
         partialsDir: defaultPartialsDirs.concat(partialsDirs),
-        helpers: helpers
+        helpers: plugins.getHelpers()
     });
 
     app.locals.config = config;

--- a/server/lib/plugins.js
+++ b/server/lib/plugins.js
@@ -1,0 +1,35 @@
+var _ = require('lodash');
+
+var combinedHelpers;
+
+function register(coreHelpers, pluginHelpers) {
+    function mergeObjects(xs) {
+        // Custom merge function ORs together non-object values, recursively
+        // calls itself on Objects.
+        var merger = function (a, b) {
+            var result;
+            if (_.isObject(a)) {
+                result = _.merge({}, a, b, merger);
+            } else {
+                result = a || b;
+            }
+            return result;
+        };
+        var args = _.flatten([{}, xs, merger]);
+        return _.merge.apply(_, args);
+    }
+
+    combinedHelpers = mergeObjects([].concat(
+        [coreHelpers],
+        pluginHelpers || []
+    ));
+}
+
+function getHelpers() {
+    return combinedHelpers;
+}
+
+module.exports = {
+    register: register,
+    getHelpers: getHelpers
+};

--- a/server/routes/generateCollection.js
+++ b/server/routes/generateCollection.js
@@ -3,9 +3,8 @@
 var path = require('path');
 var express = require('express');
 var find = require('lodash/find');
-
 var collections = require('../lib/collections');
-var helpers = require('../helpers');
+var plugins = require('../lib/plugins');
 
 /* eslint-disable max-params */
 module.exports = function (sectionConfig, directory, items, partials, data, clientDir) {
@@ -19,7 +18,7 @@ module.exports = function (sectionConfig, directory, items, partials, data, clie
             partials: partials,
             ordering: sectionConfig.ordering,
             usage: sectionConfig.showUsage,
-            helpers: helpers,
+            helpers: plugins.getHelpers(),
             data: data
         });
     }

--- a/server/routes/generateList.js
+++ b/server/routes/generateList.js
@@ -4,10 +4,9 @@ var path = require('path');
 var express = require('express');
 var find = require('lodash/find');
 var assign = require('lodash/assign');
-
 var commonVariables = require('../lib/commonVariables');
 var collections = require('../lib/collections');
-var helpers = require('../helpers');
+var plugins = require('../lib/plugins');
 
 /* eslint-disable max-params */
 module.exports = function (sectionConfig, items, partials, data, clientDir) {
@@ -18,7 +17,7 @@ module.exports = function (sectionConfig, items, partials, data, clientDir) {
     function getItems(req) {
         return collections.pages(items, {
             partials: partials,
-            helpers: helpers,
+            helpers: plugins.getHelpers(),
             data: assign(data, {
                 link: commonVariables.link(req),
                 absoluteLink: commonVariables.absoluteLink(req),


### PR DESCRIPTION
Allows template helpers to be registered by plugins (like https://github.com/MadeHQ/baseplate-cloudinary) or anything that can return an object containing handlebars helpers (allowing project specific template helpers)
